### PR TITLE
Add AST printing support with Visitor pattern implementation

### DIFF
--- a/src/com/craftinginterpretes/lox/AstPrinter.java
+++ b/src/com/craftinginterpretes/lox/AstPrinter.java
@@ -1,0 +1,50 @@
+package com.craftinginterpretes.lox;
+
+class AstPrinter implements Expr.Visitor<String> {
+    String print(Expr expr) {
+        return expr.accept(this);
+    }
+
+    @Override
+    public String visitBinaryExpr(Expr.Binary expr) {
+        return parenthesize(expr.operator.lexeme,
+                expr.left, expr.right);
+    }
+
+    @Override
+    public String visitGroupingExpr(Expr.Grouping expr) {
+        return parenthesize("group", expr.expression);
+    }
+
+    @Override
+    public String visitLiteralExpr(Expr.Literal expr) {
+        if (expr.value == null) return "nil";
+        return expr.value.toString();
+    }
+
+    @Override
+    public String visitUnaryExpr(Expr.Unary expr) {
+        return parenthesize(expr.operator.lexeme, expr.right);
+
+    }
+    private String parenthesize(String name, Expr... exprs) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("(").append(name);
+        for (Expr expr : exprs) {
+            builder.append(" ");
+            builder.append(expr.accept(this));
+        }
+        builder.append(")");
+        return builder.toString();
+    }
+    public static void main(String[] args) {
+        Expr expression = new Expr.Binary(
+                new Expr.Unary(
+                        new Token(TokenType.MINUS, "-", null, 1),
+                        new Expr.Literal(13)),
+                new Token(TokenType.STAR, "*", null, 1),
+                new Expr.Grouping(
+                        new Expr.Literal(45.67)));
+        System.out.println(new AstPrinter().print(expression));
+    }
+}

--- a/src/com/craftinginterpretes/lox/Expr.java
+++ b/src/com/craftinginterpretes/lox/Expr.java
@@ -3,38 +3,73 @@ package com.craftinginterpretes.lox;
 import java.util.List;
 
 abstract class Expr {
- static class Binary extends Expr {
- Binary(Expr left, Token operator, Expr right) {
- this.left = left;
- this.operator = operator;
- this.right = right;
- }
+    interface Visitor<R> {
+        R visitBinaryExpr(Binary expr);
 
- final Expr left;
- final Token operator;
- final Expr right;
- }
- static class Grouping extends Expr {
- Grouping(Expr expression) {
- this.expression = expression;
- }
+        R visitGroupingExpr(Grouping expr);
 
- final Expr expression;
- }
- static class Literal extends Expr {
- Literal(Object value) {
- this.value = value;
- }
+        R visitLiteralExpr(Literal expr);
 
- final Object value;
- }
- static class Unary extends Expr {
- Unary(Token operator, Expr right) {
- this.operator = operator;
- this.right = right;
- }
+        R visitUnaryExpr(Unary expr);
+    }
 
- final Token operator;
- final Expr right;
- }
+    static class Binary extends Expr {
+        Binary(Expr left, Token operator, Expr right) {
+            this.left = left;
+            this.operator = operator;
+            this.right = right;
+        }
+
+        @Override
+        <R> R accept(Visitor<R> visitor) {
+            return visitor.visitBinaryExpr(this);
+        }
+
+        final Expr left;
+        final Token operator;
+        final Expr right;
+    }
+
+    static class Grouping extends Expr {
+        Grouping(Expr expression) {
+            this.expression = expression;
+        }
+
+        @Override
+        <R> R accept(Visitor<R> visitor) {
+            return visitor.visitGroupingExpr(this);
+        }
+
+        final Expr expression;
+    }
+
+    static class Literal extends Expr {
+        Literal(Object value) {
+            this.value = value;
+        }
+
+        @Override
+        <R> R accept(Visitor<R> visitor) {
+            return visitor.visitLiteralExpr(this);
+        }
+
+        final Object value;
+    }
+
+    static class Unary extends Expr {
+        Unary(Token operator, Expr right) {
+            this.operator = operator;
+            this.right = right;
+        }
+
+        @Override
+        <R> R accept(Visitor<R> visitor) {
+            return visitor.visitUnaryExpr(this);
+        }
+
+        final Token operator;
+        final Expr right;
+    }
+
+    abstract <R> R accept(Visitor<R> visitor);
 }

--- a/src/com/craftinginterpretes/tools/GenerateAst.java
+++ b/src/com/craftinginterpretes/tools/GenerateAst.java
@@ -29,11 +29,14 @@ public class GenerateAst {
         writer.println("import java.util.List;");
         writer.println();
         writer.println("abstract class " + baseName + " {");
+        defineVisitor(writer, baseName, types);
         for (String type : types) {
             String className = type.split(":")[0].trim();
             String fields = type.split(":")[1].trim();
             defineType(writer, baseName, className, fields);
         }
+        writer.println();
+        writer.println(" abstract <R> R accept(Visitor<R> visitor);");
         writer.println("}");
         writer.close();
     }
@@ -51,11 +54,30 @@ public class GenerateAst {
             writer.println(" this." + name + " = " + name + ";");
         }
         writer.println(" }");
+        writer.println();
+        writer.println(" @Override");
+        writer.println(" <R> R accept(Visitor<R> visitor) {");
+        writer.println(" return visitor.visit" +
+                className + baseName + "(this);");
+        writer.println(" }");
 // Fields.
         writer.println();
         for (String field : fields) {
             writer.println(" final " + field + ";");
         }
         writer.println(" }");
+
+    }
+    private static void defineVisitor(
+            PrintWriter writer, String baseName, List<String> types) {
+        writer.println(" interface Visitor<R> {");
+
+        for (String type : types) {
+            String typeName = type.split(":")[0].trim();
+            writer.println(" R visit" + typeName + baseName + "(" +
+                    typeName + " " + baseName.toLowerCase() + ");");
+        }
+        writer.println(" }");
+
     }
 }


### PR DESCRIPTION
Introduced an `AstPrinter` class to allow expression tree printing using the Visitor pattern. Extended the `Expr` hierarchy to support the Visitor interface, enabling clean traversal of expression nodes. Updated `GenerateAst` to automate the generation of the Visitor pattern for new syntax types.